### PR TITLE
Revert "feat: set up fed.brid.gy"

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,0 @@
-/.well-known/host-meta* https://fed.brid.gy/.well-known/host-meta:splat 301
-/.well-known/webfinger* https://fed.brid.gy/.well-known/webfinger:splat 301


### PR DESCRIPTION
Custom domain is not available when syncing from Bluesky to Fediverse.